### PR TITLE
Add missing dependency inotify-simple to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ packages = service
 install_requires =
     configobj
     hidapi
-    inotify
     inotify_simple
     pyroute2
     systemd-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     configobj
     hidapi
     inotify
+    inotify_simple
     pyroute2
     systemd-python
    


### PR DESCRIPTION
Noticed that the package uses inotify-simple, but forgets to pull it in correctly. This breaks the installation on Arch Linux, so I've gone ahead and added it.