### PR TITLE
Fix typo in dev_desc for product ID

### DIFF
--- a/service/kbd_bl_api.py
+++ b/service/kbd_bl_api.py
@@ -8,7 +8,7 @@ class LenovoKeyboardBacklight:
 
     def __enter__(self):
         dev_desc = next(desc for desc in hid.enumerate(vendor_id=0x048d) if desc['product_id'] in [ 0xc965, 0xc955 ])
-        self.dev.open(dev_desc['vendor_id'], dev_decs['product_id'])
+        self.dev.open(dev_desc['vendor_id'], dev_desc['product_id'])
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Typo fix: `dev_decs -> dev_desc`. Blocks startup from systemd if left unresolved.